### PR TITLE
make Solana.toml optional for deploy command

### DIFF
--- a/.changeset/curvy-cycles-march.md
+++ b/.changeset/curvy-cycles-march.md
@@ -1,0 +1,5 @@
+---
+"mucho": minor
+---
+
+make Solana.toml optional for deploy command


### PR DESCRIPTION
#### Problem #26 



#### Summary of Changes
Added changes to make `Solana.toml` entirely optional.

With `Solana.toml`:
- Uses program IDs and settings from the toml if available
- Falls back to auto-detection if program/cluster not found in toml

Without `Solana.toml`:
- Auto-detects program ID from build directory keypair
- Uses default keypair locations

`Solana.toml` is now meant to be a convenient way to specify settings but not a requirement for deployment.


Fixes #26 