### PR TITLE
fix: default help for subcommands

### DIFF
--- a/.changeset/ninety-pans-smash.md
+++ b/.changeset/ninety-pans-smash.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+fix help flag being added to all commands

--- a/src/commands/token.ts
+++ b/src/commands/token.ts
@@ -1,16 +1,11 @@
 import { Command } from "@commander-js/extra-typings";
-import { cliOutputConfig } from "@/lib/cli";
+import { cliOutputConfig, setHelpCommandAsDefault } from "@/lib/cli";
 import { createTokenCommand } from "./token/create";
 import { mintTokenCommand } from "./token/mint";
 import { transferTokenCommand } from "./token/transfer";
 
 export function tokenCommand() {
-  // set the default action to `help` without an error
-  if (process.argv.length === 3) {
-    process.argv.push("--help");
-  }
-
-  return new Command("token")
+  return new Command(setHelpCommandAsDefault("token"))
     .configureOutput(cliOutputConfig)
     .description("create, mint, and transfer tokens")
     .addCommand(createTokenCommand())

--- a/src/lib/cli/help.ts
+++ b/src/lib/cli/help.ts
@@ -1,0 +1,24 @@
+/**
+ * Make the default output for a given command be the `--help` response
+ *
+ * Offset: default arg offset to get the user supplied command
+ * - [0]  = node
+ * - [1]  = mucho
+ * - [2+] = command and args
+ */
+export function setHelpCommandAsDefault(
+  command: string,
+  offset: number = 2,
+): string {
+  const splitter = command.toLowerCase().split(" ");
+  const checkCommand = process.argv.slice(offset, offset + splitter.length);
+
+  // only add the help flag when the configured command is used
+  if (checkCommand.join(" ").toLowerCase() == splitter.join(" ")) {
+    if (process.argv.length === offset + splitter.length) {
+      process.argv.push("--help");
+    }
+  }
+
+  return splitter.slice(splitter.length - 1)[0];
+}

--- a/src/lib/cli/index.ts
+++ b/src/lib/cli/index.ts
@@ -1,1 +1,2 @@
 export * from "./config";
+export * from "./help";


### PR DESCRIPTION
#### Problem

some subcommands set the default action to display the help text, by inserting the `--help` flag to the `process.argv`. this was implemented foolishly and will override them for all commands instead of just a specific one

#### Summary of Changes

make a smarter "set help as default response" function and use it