### PR TITLE
feat: added localnet checks

### DIFF
--- a/.changeset/plenty-meals-roll.md
+++ b/.changeset/plenty-meals-roll.md
@@ -1,0 +1,5 @@
+---
+"mucho": minor
+---
+
+added localnet validator checks on token commands

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -2,7 +2,12 @@ import path from "path";
 import { Command, Option } from "@commander-js/extra-typings";
 import { cliConfig, COMMON_OPTIONS } from "@/const/commands";
 import { cliOutputConfig, loadConfigToml } from "@/lib/cli";
-import { cancelMessage, titleMessage, warnMessage } from "@/lib/logs";
+import {
+  cancelMessage,
+  titleMessage,
+  warningOutro,
+  warnMessage,
+} from "@/lib/logs";
 import { checkCommand, shellExecInSession } from "@/lib/shell";
 import {
   buildDeployProgramCommand,
@@ -111,8 +116,8 @@ export function deployCommand() {
         }
       }
 
-      if (!getRunningTestValidatorCommand()) {
-        return warnMessage(
+      if (selectedCluster == "localnet" && !getRunningTestValidatorCommand()) {
+        return warningOutro(
           `Attempted to deploy to localnet with no local validator running. Operation canceled.`,
         );
       }

--- a/src/commands/token/mint.ts
+++ b/src/commands/token/mint.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "@commander-js/extra-typings";
 import { cliOutputConfig, loadSolanaCliConfig } from "@/lib/cli";
 import { COMMON_OPTIONS } from "@/const/commands";
-import { errorOutro, titleMessage } from "@/lib/logs";
+import { errorOutro, titleMessage, warningOutro } from "@/lib/logs";
 import ora from "ora";
 
 import { wordWithPlurality } from "@/lib/utils";
@@ -18,6 +18,7 @@ import { loadKeypairSignerFromFile } from "gill/node";
 import { parseOrLoadSignerAddress } from "@/lib/gill/keys";
 import { parseOptionsFlagForRpcUrl } from "@/lib/cli/parsers";
 import { simulateTransactionOnThrow } from "@/lib/gill/errors";
+import { getRunningTestValidatorCommand } from "@/lib/shell/test-validator";
 
 export function mintTokenCommand() {
   return new Command("mint")
@@ -71,6 +72,16 @@ export function mintTokenCommand() {
         /* use the Solana cli config's rpc url as the fallback */
         loadSolanaCliConfig().json_rpc_url,
       );
+
+      if (
+        parsedRpcUrl.cluster == "localhost" &&
+        !getRunningTestValidatorCommand()
+      ) {
+        spinner.stop();
+        return warningOutro(
+          `Attempted to use localnet with no local validator running. Operation canceled.`,
+        );
+      }
 
       if (!options.mint) {
         return errorOutro(

--- a/src/commands/token/transfer.ts
+++ b/src/commands/token/transfer.ts
@@ -1,7 +1,7 @@
 import { Command, Option } from "@commander-js/extra-typings";
 import { cliOutputConfig, loadSolanaCliConfig } from "@/lib/cli";
 import { COMMON_OPTIONS } from "@/const/commands";
-import { errorOutro, titleMessage } from "@/lib/logs";
+import { errorOutro, titleMessage, warningOutro } from "@/lib/logs";
 import ora from "ora";
 
 import { wordWithPlurality } from "@/lib/utils";
@@ -22,6 +22,7 @@ import { loadKeypairSignerFromFile } from "gill/node";
 import { parseOrLoadSignerAddress } from "@/lib/gill/keys";
 import { parseOptionsFlagForRpcUrl } from "@/lib/cli/parsers";
 import { simulateTransactionOnThrow } from "@/lib/gill/errors";
+import { getRunningTestValidatorCommand } from "@/lib/shell/test-validator";
 
 export function transferTokenCommand() {
   return new Command("transfer")
@@ -75,6 +76,16 @@ export function transferTokenCommand() {
         /* use the Solana cli config's rpc url as the fallback */
         loadSolanaCliConfig().json_rpc_url,
       );
+
+      if (
+        parsedRpcUrl.cluster == "localhost" &&
+        !getRunningTestValidatorCommand()
+      ) {
+        spinner.stop();
+        return warningOutro(
+          `Attempted to use localnet with no local validator running. Operation canceled.`,
+        );
+      }
 
       if (!options.mint) {
         return errorOutro(


### PR DESCRIPTION
#### Problem

if the `token` commands attempt to use localnet without the validator running, the user gets a generic/useless message

#### Summary of Changes

added the localnet running checks for the token commands