### PR TITLE
make cargo installer optional

### DIFF
--- a/.changeset/sweet-countries-film.md
+++ b/.changeset/sweet-countries-film.md
@@ -1,0 +1,5 @@
+---
+"mucho": patch
+---
+
+make the cargo updater an optional install

--- a/src/lib/shell/index.ts
+++ b/src/lib/shell/index.ts
@@ -53,29 +53,24 @@ export async function checkCommand(
     if (errorOptions) throw "Command not found";
     return false;
   } catch (err) {
-    if (errorOptions) {
-      // execute the onError function
-      if (typeof errorOptions?.onError == "function") {
-        // the onError function can attempt to fix the error of the command not executing
-        // (like prompting the user to install a command)
-        const res = await errorOptions.onError();
+    if (!errorOptions) return false;
+    // execute the onError function
+    if (typeof errorOptions?.onError == "function") {
+      // the onError function can attempt to fix the error of the command not executing
+      // (like prompting the user to install a command)
+      const res = await errorOptions.onError();
 
-        if (errorOptions.doubleCheck) {
-          return await checkCommand(cmd, {
-            exit: errorOptions.exit,
-          });
-        }
-
-        if (!res && errorOptions?.exit) process.exit(1);
-      } else {
-        warnMessage(
-          errorOptions.message ||
-            `Unable to execute command: ${cmd.split(" ")[0]}`,
-        );
-        if (errorOptions.exit) process.exit(1);
+      if (errorOptions.doubleCheck) {
+        return await checkCommand(cmd, {
+          exit: errorOptions.exit,
+        });
       }
+
+      if (!res && errorOptions?.exit) process.exit(1);
+    } else {
+      warnMessage(errorOptions.message || `Unable to execute command: ${cmd}`);
+      if (errorOptions.exit) process.exit(1);
     }
-    return false;
   }
 }
 

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -44,7 +44,7 @@ export async function getNpmPackageUpdates(
  */
 export async function getCargoUpdateOutput(): Promise<PackageUpdate[]> {
   const res = await checkCommand("cargo install-update --git --list", {
-    exit: true,
+    exit: false,
     onError: async () => {
       warnMessage(
         "Unable to detect the 'cargo install-update' command. Installing...",


### PR DESCRIPTION
#### Problem

mucho uses the `install-update` crate to determine if on of the installed tools has an update available. currently, this is a required install tool when running `mucho install`. 

however, if the user's system fails to install this binary (or build it) then the entire install is exited

#### Summary of Changes

make the `install-update` tool optional and not prevent the installer from continuing