### PR TITLE
add an error logger

### DIFF
--- a/.changeset/neat-hotels-notice.md
+++ b/.changeset/neat-hotels-notice.md
@@ -1,0 +1,5 @@
+---
+"mucho": minor
+---
+
+added an error logger

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -6,6 +6,7 @@ import { COMMON_OPTIONS } from "@/const/commands";
 import { autoLocateProgramsInWorkspace, loadCargoToml } from "@/lib/cargo";
 import { buildProgramCommand } from "@/lib/shell/build";
 import { doesFileExist } from "@/lib/utils";
+import { logger } from "@/lib/logger";
 
 /**
  * Command: `build`
@@ -65,7 +66,7 @@ export function buildCommand() {
           );
 
           // todo: should we prompt the user to select a valid program?
-          process.exit();
+          logger.exit();
         }
       }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -14,6 +14,7 @@ import { getSafeClusterMoniker, parseRpcUrlOrMoniker } from "@/lib/solana";
 import { promptToSelectCluster } from "@/lib/prompts/build";
 import { loadKeypairSignerFromFile } from "gill/node";
 import { getRunningTestValidatorCommand } from "@/lib/shell/test-validator";
+import { logger } from "@/lib/logger";
 
 /**
  * Command: `deploy`
@@ -81,7 +82,7 @@ export function deployCommand() {
         );
 
         // todo: should we prompt the user to select a valid program?
-        process.exit();
+        logger.exit();
       }
 
       if (!options.url) {
@@ -165,17 +166,16 @@ export function deployCommand() {
             });
           });
 
-          process.exit();
+          logger.exit();
         }
 
         if (
           !config?.programs?.[selectedCluster] ||
           !Object.hasOwn(config.programs[selectedCluster], options.programName)
         ) {
-          warnMessage(
+          return warningOutro(
             `Program '${options.programName}' not found in 'programs.${selectedCluster}'`,
           );
-          process.exit();
         }
 
         programId = config.programs[selectedCluster][options.programName];
@@ -189,8 +189,9 @@ export function deployCommand() {
           console.log(` - keypair path: ${programIdPath}`);
           console.log(` - program id: ${programId}`);
         } else {
-          warnMessage(`Unable to locate any program id or program keypair.`);
-          process.exit();
+          return warningOutro(
+            `Unable to locate any program id or program keypair.`,
+          );
         }
       }
 
@@ -232,7 +233,7 @@ export function deployCommand() {
           warnMessage(
             `Unable to perform initial program deployment. Operation cancelled.`,
           );
-          process.exit();
+          logger.exit();
           // todo: should we prompt the user if they want to proceed
         }
         programId = programIdFromKeypair;

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -2,12 +2,7 @@ import path from "path";
 import { Command, Option } from "@commander-js/extra-typings";
 import { cliConfig, COMMON_OPTIONS } from "@/const/commands";
 import { cliOutputConfig, loadConfigToml } from "@/lib/cli";
-import {
-  cancelMessage,
-  titleMessage,
-  warningOutro,
-  warnMessage,
-} from "@/lib/logs";
+import { titleMessage, warningOutro, warnMessage } from "@/lib/logs";
 import { checkCommand, shellExecInSession } from "@/lib/shell";
 import {
   buildDeployProgramCommand,
@@ -258,13 +253,13 @@ export function deployCommand() {
        */
       if (programInfo) {
         if (!programInfo.authority) {
-          return cancelMessage(
+          return warningOutro(
             `Program ${programInfo.programId} is no longer upgradeable`,
           );
         }
 
         if (programInfo.authority !== authorityKeypair.address) {
-          return cancelMessage(
+          return warningOutro(
             `Your keypair (${authorityKeypair.address}) is not the upgrade authority for program ${programId}`,
           );
         }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,6 +4,7 @@ import { getAppInfo } from "@/lib/app-info";
 import { getCommandOutputSync } from "@/lib/shell";
 import { getPlatformToolsVersions } from "@/lib/solana";
 import { TOOL_CONFIG } from "@/const/setup";
+import { logger } from "@/lib/logger";
 
 export function cliProgramRoot() {
   // console.log(picocolors.bgMagenta(` ${app.name} - v${app.version} `));
@@ -39,7 +40,7 @@ export function cliProgramRoot() {
 
         console.log("\nFor more info run: 'npx mucho info'");
       }
-      process.exit(0);
+      logger.exit(0);
     });
 
   return program;

--- a/src/commands/validator.ts
+++ b/src/commands/validator.ts
@@ -23,6 +23,7 @@ import { cloneCommand } from "@/commands/clone";
 import { getAppInfo } from "@/lib/app-info";
 import { loadKeypairSignerFromFile } from "gill/node";
 import { getExplorerLink } from "gill";
+import { logger } from "@/lib/logger";
 
 /**
  * Command: `validator`
@@ -41,7 +42,7 @@ export function validatorCommand() {
       getCommandOutputSync("solana-test-validator --version") ||
         `solana-test-validator not found`,
     );
-    process.exit();
+    logger.exit();
   }
 
   return new Command("validator")
@@ -166,7 +167,7 @@ export function validatorCommand() {
 
       if (options.verbose) console.log(`\n${command}\n`);
       // only log the "run validator" command, do not execute it
-      if (options.outputOnly) process.exit();
+      if (options.outputOnly) logger.exit();
 
       if (options.reset && options.verbose) {
         console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,11 @@ assertRuntimeVersion();
 suppressRuntimeWarnings();
 patchBigint();
 
+import { logger } from "@/lib/logger";
+// we expect this to NOT create the log file due to no errors existing
+// but this ensure we have global import access to the logger as soon as the command is run
+logger.ensureLogFile();
+
 import { checkForSelfUpdate } from "@/lib/npm";
 import { errorOutro } from "@/lib/logs";
 import { cliProgramRoot } from "@/commands";

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,20 @@ suppressRuntimeWarnings();
 patchBigint();
 
 import { logger } from "@/lib/logger";
-// we expect this to NOT create the log file due to no errors existing
-// but this ensure we have global import access to the logger as soon as the command is run
-logger.ensureLogFile();
+// we expect this to do nothing really but it ensures we have global
+// import access to the logger as soon as the command is run
+logger.getLogs();
+
+// create the global error boundary
+process.on("uncaughtException", (err) => {
+  logger.error("Uncaught exception", err);
+
+  let message = "An uncaught exception has occurred";
+  if (typeof err == "string") message += `: ${err}`;
+  else if (err instanceof Error) message += `: ${err.name}: ${err.message}`;
+
+  errorOutro(message, "[Uncaught exception]");
+});
 
 import { checkForSelfUpdate } from "@/lib/npm";
 import { errorOutro } from "@/lib/logs";
@@ -34,46 +45,37 @@ import { balanceCommand } from "@/commands/balance";
 import { selfUpdateCommand } from "./commands/self-update";
 
 async function main() {
-  // create a global error boundary
-  try {
-    // auto check for new version of the cli when not attempting the self-update
-    if (
-      process.argv?.[2]?.toLowerCase() !== "self-update" ||
-      process.argv?.[3]?.toLowerCase() === "--help"
-    ) {
-      await checkForSelfUpdate();
-    }
-
-    try {
-      const program = cliProgramRoot();
-
-      program
-        .addCommand(installCommand())
-        // .addCommand(doctorCommand())
-        .addCommand(validatorCommand())
-        .addCommand(inspectCommand())
-        .addCommand(cloneCommand())
-        .addCommand(buildCommand())
-        .addCommand(deployCommand())
-        .addCommand(tokenCommand())
-        .addCommand(balanceCommand())
-        .addCommand(coverageCommand())
-        .addCommand(infoCommand())
-        .addCommand(docsCommand())
-        .addCommand(selfUpdateCommand());
-
-      // set the default action to `help` without an error
-      if (process.argv.length === 2) {
-        process.argv.push("--help");
-      }
-
-      await program.parseAsync();
-    } catch (err) {
-      errorOutro(err.toString());
-    }
-  } catch (err) {
-    errorOutro(err, "[mucho - unhandled error]");
+  // auto check for new version of the cli when not attempting the self-update
+  if (
+    process.argv?.[2]?.toLowerCase() !== "self-update" ||
+    process.argv?.[3]?.toLowerCase() === "--help"
+  ) {
+    await checkForSelfUpdate();
   }
+
+  const program = cliProgramRoot();
+
+  program
+    .addCommand(installCommand())
+    // .addCommand(doctorCommand())
+    .addCommand(validatorCommand())
+    .addCommand(inspectCommand())
+    .addCommand(cloneCommand())
+    .addCommand(buildCommand())
+    .addCommand(deployCommand())
+    .addCommand(tokenCommand())
+    .addCommand(balanceCommand())
+    .addCommand(coverageCommand())
+    .addCommand(infoCommand())
+    .addCommand(docsCommand())
+    .addCommand(selfUpdateCommand());
+
+  // set the default action to `help` without an error
+  if (process.argv.length === 2) {
+    process.argv.push("--help");
+  }
+
+  await program.parseAsync();
 
   // add a line spacer at the end to make the terminal easier to read
   console.log();

--- a/src/lib/cli/config.ts
+++ b/src/lib/cli/config.ts
@@ -81,7 +81,6 @@ export function loadConfigToml(
   } else {
     if (isConfigRequired) {
       warningOutro(`No Solana.toml config file found. Operation canceled.`);
-      process.exit();
     }
   }
 

--- a/src/lib/install.ts
+++ b/src/lib/install.ts
@@ -14,6 +14,7 @@ import ora from "ora";
 import { TOOL_CONFIG } from "@/const/setup";
 import picocolors from "picocolors";
 import { getCurrentNpmPackageVersion } from "./npm";
+import { logger } from "./logger";
 
 /**
  * Install the mucho cli
@@ -136,7 +137,7 @@ export async function installRust({}: InstallCommandPropsBase = {}) {
           missingDeps.join(" "),
         );
 
-        process.exit(0);
+        logger.exit(0);
       }
     }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -84,7 +84,7 @@ class ErrorLogger {
     if (this.logFilePath) {
       console.error(
         picocolors.red(
-          `An error occurred during execution.\n` +
+          `\nAn error occurred during execution.\n` +
             `See the full log at: ${this.logFilePath}`,
         ),
       );

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,152 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { getAppInfo } from "./app-info";
+
+class ErrorLogger {
+  private logFilePath: string | null = null;
+  private logs: string[] = [];
+  private appName: string;
+  private timestamp: string;
+
+  constructor(appName: string) {
+    this.appName = appName;
+    this.timestamp = new Date().toISOString();
+
+    // Initialize the log file with header
+    this.logs.push(
+      `# Error Log: ${this.appName}`,
+      `Timestamp: ${this.timestamp}`,
+      `Command:   ${process.argv.slice(0, 2).join(" ")}`,
+      `Arguments: ${
+        process.argv.length > 2 ? process.argv.slice(2).join(" ") : "<NONE>"
+      }`,
+      `----------`,
+    );
+  }
+
+  /**
+   * Log the args used on the command
+   */
+  public logArgs(): void {
+    // const formattedMessage = `Args: ${process.argv.join(" ")}`;
+    // this.logs.push(formattedMessage);
+  }
+
+  /**
+   * Log an informational message
+   */
+  public info(message: string): void {
+    const formattedMessage = `[INFO] ${new Date().toISOString()}: ${message}`;
+    this.logs.push(formattedMessage);
+  }
+
+  /**
+   * Log a warning message
+   */
+  public warn(message: string): void {
+    const formattedMessage = `[WARN] ${new Date().toISOString()}: ${message}`;
+    this.logs.push(formattedMessage);
+  }
+
+  /**
+   * Log an error message and create log file if it doesn't exist yet
+   */
+  public error(message: string, error?: Error | string): void {
+    let formattedMessage = `[ERROR] ${new Date().toISOString()}: ${message}`;
+
+    if (error) {
+      if (error instanceof Error) {
+        formattedMessage += `\nError: ${error.message}`;
+        if (error.stack) {
+          formattedMessage += `\nStack trace:\n${error.stack}`;
+        }
+      } else if (typeof error == "string") {
+        formattedMessage += `\nError: ${error}`;
+      }
+    }
+
+    this.logs.push(formattedMessage);
+
+    // Create the log file now that we have an error
+    this.ensureLogFile();
+
+    // Write all accumulated logs to the file
+    this.flushLogsToFile();
+  }
+
+  /**
+   * Get the path to the log file
+   * Returns null if no errors have been logged yet
+   */
+  public getLogFilePath(): string | null {
+    return this.logFilePath;
+  }
+
+  /**
+   * Print error notification to console
+   * Only prints if an error has been logged
+   */
+  public printErrorNotification(): void {
+    if (this.logFilePath) {
+      console.error(
+        "An error occurred during execution.",
+        "See the full log at:",
+        this.logFilePath,
+      );
+    }
+  }
+
+  /**
+   * Exit the logger and print the error notification if needed
+   */
+  public exit(): void {
+    // const formattedMessage = `Args: ${process.argv.join(" ")}`;
+    // this.logs.push(formattedMessage);
+
+    this.printErrorNotification();
+    process.exit();
+  }
+
+  /**
+   * Get all logged messages
+   */
+  public getLogs(): string[] {
+    return [...this.logs];
+  }
+
+  /**
+   * Create the log file if it doesn't exist yet
+   */
+  public ensureLogFile(): void {
+    if (!this.logFilePath) {
+      // Create a unique filename with timestamp
+      const filename = `${this.appName}-error-${this.timestamp.replace(
+        /:/g,
+        "-",
+      )}.log`;
+
+      this.logFilePath = path.join(os.tmpdir(), filename);
+      fs.writeFileSync(this.logFilePath, "");
+    }
+  }
+
+  /**
+   * Write all accumulated logs to the file
+   */
+  private flushLogsToFile(): void {
+    if (!this.logFilePath) return;
+
+    try {
+      const content = this.logs.join("\n") + "\n";
+      fs.writeFileSync(this.logFilePath, content, { flag: "w" });
+    } catch (err) {
+      console.error("Failed to write to log file:", err);
+    }
+
+    // Clear the logs array after flushing
+    this.logs = [];
+  }
+}
+
+export const logger = new ErrorLogger(getAppInfo().name);

--- a/src/lib/logs.ts
+++ b/src/lib/logs.ts
@@ -1,5 +1,6 @@
 import picocolors from "picocolors";
 import type { Formatter } from "picocolors/types";
+import { logger } from "./logger";
 
 /**
  * Print a plain message using `picocolors`
@@ -22,18 +23,9 @@ export function warnMessage(msg: string) {
 /**
  * Show a cancel outro and exit the cli process
  */
-export function cancelMessage(msg: string = "Operation canceled") {
-  console.log(msg);
-  // cancel(msg);
-  process.exit();
-}
-
-/**
- * Show a cancel outro and exit the cli process
- */
 export function warningOutro(msg: string = "Operation canceled") {
   warnMessage(msg);
-  process.exit();
+  logger.exit();
 }
 
 /**
@@ -43,7 +35,7 @@ export function warningOutro(msg: string = "Operation canceled") {
 export function cancelOutro(msg: string = "Operation canceled") {
   console.log(picocolors.inverse(` ${msg} `), "\n");
   // outro(picocolors.inverse(` ${msg} `));
-  process.exit(0);
+  logger.exit(0);
 }
 
 /**
@@ -53,7 +45,7 @@ export function cancelOutro(msg: string = "Operation canceled") {
 export function noticeOutro(msg: string) {
   // outro(picocolors.bgBlue(` ${msg} `));
   console.log(picocolors.bgBlue(` ${msg} `), "\n");
-  process.exit(0);
+  logger.exit(0);
 }
 
 /**
@@ -63,7 +55,7 @@ export function noticeOutro(msg: string) {
 export function successOutro(msg: string = "Operation successful") {
   console.log(picocolors.bgGreen(` ${msg} `), "\n");
   // outro(picocolors.bgGreen(` ${msg} `));
-  process.exit(0);
+  logger.exit(0);
 }
 
 /**
@@ -76,7 +68,7 @@ export function errorOutro(
   extraLog?: any,
 ) {
   errorMessage(msg, title, extraLog);
-  process.exit(1);
+  logger.exit(1);
 }
 
 /**

--- a/src/lib/prompts/build.ts
+++ b/src/lib/prompts/build.ts
@@ -1,5 +1,6 @@
 import { select } from "@inquirer/prompts";
 import { SolanaClusterMoniker } from "gill";
+import { logger } from "../logger";
 
 export async function promptToSelectCluster(
   message: string = "Select a cluster?",
@@ -56,7 +57,7 @@ export async function promptToSelectCluster(
        */
       // do nothing on user cancel instead of exiting the cli
       console.log("Operation canceled.");
-      process.exit();
+      logger.exit();
       // todo: support selecting a default value here?
       return defaultValue;
     });

--- a/src/lib/prompts/clone.ts
+++ b/src/lib/prompts/clone.ts
@@ -1,5 +1,6 @@
 import { select } from "@inquirer/prompts";
 import { cloneCommand } from "@/commands/clone";
+import { logger } from "../logger";
 
 export async function promptToAutoClone(): Promise<void | boolean> {
   console.log(); // print a line separator
@@ -37,7 +38,6 @@ export async function promptToAutoClone(): Promise<void | boolean> {
        */
       // do nothing on user cancel instead of exiting the cli
       console.log("Operation canceled.");
-      process.exit();
-      return;
+      return logger.exit();
     });
 }

--- a/src/lib/prompts/install.ts
+++ b/src/lib/prompts/install.ts
@@ -1,5 +1,6 @@
 import { select } from "@inquirer/prompts";
 import { ToolNames } from "@/types";
+import { logger } from "../logger";
 
 export async function promptToInstall(
   toolName: ToolNames,
@@ -33,7 +34,6 @@ export async function promptToInstall(
        */
       // do nothing on user cancel instead of exiting the cli
       console.log("Operation canceled.");
-      process.exit();
-      return;
+      return logger.exit();
     });
 }

--- a/src/lib/shell/index.ts
+++ b/src/lib/shell/index.ts
@@ -6,6 +6,7 @@ import shellExec from "shell-exec";
 import { TOOL_CONFIG } from "@/const/setup";
 import { warnMessage } from "@/lib/logs";
 import { type ChildProcess, execSync, spawn } from "node:child_process";
+import { logger } from "../logger";
 
 export const VERSION_REGEX = /(?:[\w-]+\s+)?(\d+\.\d+\.?\d+?)/;
 
@@ -66,13 +67,13 @@ export async function checkCommand(
           });
         }
 
-        if (!res && errorOptions?.exit) process.exit(1);
+        if (!res && errorOptions?.exit) logger.exit(1);
       } else {
         warnMessage(
           errorOptions.message ||
             `Unable to execute command: ${cmd.split(" ")[0]}`,
         );
-        if (errorOptions.exit) process.exit(1);
+        if (errorOptions.exit) logger.exit(1);
       }
     }
     return false;

--- a/src/lib/shell/index.ts
+++ b/src/lib/shell/index.ts
@@ -67,10 +67,10 @@ export async function checkCommand(
         });
       }
 
-      if (!res && errorOptions?.exit) process.exit(1);
+      if (!res && errorOptions?.exit) logger.exit(1);
     } else {
       warnMessage(errorOptions.message || `Unable to execute command: ${cmd}`);
-      if (errorOptions.exit) process.exit(1);
+      if (errorOptions.exit) logger.exit(1);
     }
   }
 }


### PR DESCRIPTION
#### Problem

mucho does not have an error logger, making it difficult to fully know and troubleshoot errors that a user might see.

#### Summary of Changes

- add a basic error logger that lazy creates an error file
- updated all required `process.exit()` references to use `logger.exit()` in order to properly flush the queued log entries