### PR TITLE
Fix cargo update parser: Handle spinner output (dots), git packages, and array bounds checking

### DIFF
--- a/.changeset/polite-boats-beam.md
+++ b/.changeset/polite-boats-beam.md
@@ -1,0 +1,6 @@
+---
+"mucho": patch
+---
+
+Fix cargo update parser: Handle spinner output, git packages, and array bounds
+checking

--- a/src/lib/shell/index.ts
+++ b/src/lib/shell/index.ts
@@ -47,8 +47,11 @@ export async function checkCommand(
   try {
     const { stdout } = await shellExec(cmd);
 
-    if (stdout) {
-      return stdout.trim();
+    // Remove the dots from the output
+    const cleanedOutput = stdout.replace(/^\s*\.\s*$/gm, "");
+
+    if (cleanedOutput) {
+      return cleanedOutput.trim();
     }
 
     if (errorOptions) throw "Command not found";

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -66,6 +66,11 @@ export async function getCargoUpdateOutput(): Promise<PackageUpdate[]> {
   let currentChunk: string[] = [];
 
   for (const line of linesToParse) {
+    if (line.includes("Checking") && line.includes("git packages")) {
+      // Skip this line as it's just a header for git packages
+      continue;
+    }
+
     if (line.startsWith("Package")) {
       if (currentChunk.length > 1) {
         processChunk(currentChunk, results);
@@ -95,6 +100,10 @@ function processChunk(chunk: string[], results: PackageUpdate[]) {
 
   for (const line of dataLines) {
     const parts = line.split(/\s+/).filter((part) => part.length > 0);
+
+    if (parts.length < 4) {
+      continue;
+    }
 
     if (isCommitHash) {
       results.push({


### PR DESCRIPTION
#### Problem

While running `npx -y mucho@latest install` I get the following error

<img width="571" alt="Image" src="https://github.com/user-attachments/assets/df75ba54-509d-47ad-a535-a914471cdab0" />


```bash
Install Solana development tools
ℹ mucho 0.9.0 is already installed
ℹ rust 1.84.0 is already installed
 An error occurred
TypeError: Cannot read properties of undefined (reading 'toLowerCase')
```

This is coming from `getCargoUpdateOutput()` in `commands/install.ts` file

Log of stdout when we call `checkCommand()` inside `getCargoUpdateOutput()`:
```bash
stdout     Polling registry 'https://index.crates.io/'
.
.



Package       Installed  Latest   Needs update
mdbook        v0.4.47    v0.4.48  Yes
cargo-update  v16.3.0    v16.3.0  No

    Checking 1 git packages
.

Package  Installed                                 Latest                                    Needs update
avm      649b9d6c5ef19d8e15ea35888f0b1a846cd03b48  649b9d6c5ef19d8e15ea35888f0b1a846cd03b48  No
```

I assume the dots are coming because of certain 'spinner' ascii character.
The dots pollute the response, and the parser breaks

Another observation is that, the parser is not handling cases for `Checking {number} git packages`

Also, the code breaks here:

```ts
results.push({
        name: parts[0],
        installed: parts[1],
        latest: parts[2],
        needsUpdate: parts[3].toLowerCase() === "yes",
});
```

There is no length check for parts

List of issues:

-  [`checkCommand`](https://github.com/solana-foundation/mucho/blob/master/src/lib/shell/index.ts#L38) function returns unsanitized output, that includes dots(.)
- [`getCargoUpdateOutput`](https://github.com/solana-foundation/mucho/blob/master/src/lib/update.ts#L45) parser doesn't handle the case for `Checking {number} git packages`
- [`processChunk`](https://github.com/solana-foundation/mucho/blob/master/src/lib/update.ts#L87) doesn't check length of `parts` variable before pushing to `results` array

#### Summary of Changes
The fix addresses these issues by:
- Cleaning up command output by removing standalone periods and ensuring only non-empty results are returned
- Adding a filter to explicitly skip header lines containing "Checking" and "git packages" text
- Adding validation to skip any data lines that contain fewer than four parts after splitting

Fixes #93 
